### PR TITLE
Fix filterLess comparator for C++17 compatibility

### DIFF
--- a/MincoCar/include/geo_utils/geo_utils_3d.hpp
+++ b/MincoCar/include/geo_utils/geo_utils_3d.hpp
@@ -88,6 +88,7 @@ namespace geo_utils_3d
     {
         inline bool operator()(const Eigen::Vector3d &l,
                                const Eigen::Vector3d &r)
+                               const noexcept
         {
             return l(0) < r(0) ||
                    (l(0) == r(0) &&


### PR DESCRIPTION
Description:
This PR fixes build errors under C++17 caused by the filterLess comparator not being marked const.

In C++17, comparison functors used in associative containers (e.g. std::set, std::map) must be invocable as const. Without this, compilation fails with:
```bash
error: static assertion failed: comparison object must be invocable as const
```
